### PR TITLE
Ability to manage hidden folders as an archive

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -57,8 +57,8 @@ export default class NoteArchiverPlugin extends Plugin {
 			this.app.workspace.on("file-menu", (menu, file) => {
 				if (!file.path.startsWith(this.settings.archiveFolderName)) {
 					menu.addItem((item) => {
-						item.setTitle("📤 Archive file")
-							.setIcon("document")
+						item.setTitle("Archive file")
+							.setIcon("archive")
 							.onClick(async () => {
 								this.archivePage(file.path);
 							});
@@ -77,8 +77,8 @@ export default class NoteArchiverPlugin extends Plugin {
 						path &&
 						!path.startsWith(this.settings.archiveFolderName)
 					) {
-						item.setTitle("📤 Archive file")
-							.setIcon("document")
+						item.setTitle("Archive file")
+							.setIcon("archive")
 							.onClick(async () => {
 								this.archivePage(path ?? "");
 							});


### PR DESCRIPTION
I thought it would be useful to make the plugin able to manage hidden folders as an archive. This is to prevent archived notes from being indexed by Obsidian. I also made some changes to fix the issues indicated by eslint.